### PR TITLE
Basic implementation of (s)printf using @(s)printf macros.

### DIFF
--- a/src/cformat.jl
+++ b/src/cformat.jl
@@ -1,3 +1,42 @@
+###########
+#
+# Implementation of printf() and sprintf() that uses generated functions
+# and the existing @printf and @sprintf macros.
+#
+# Original work by Tim Holy. Minor edits by Daniel Carrera.
+#
+immutable FormatString{S} end
+
+FormatString(str::AbstractString) = FormatString{symbol(str)}
+
+@generated function Base.print{format}(::Type{FormatString{format}}, args...)
+    meta = Expr(:meta, :inline)
+    fmt = string(format)
+    allargs = [:(args[$d]) for d = 1:length(args)]
+    quote
+        @printf($fmt, $(allargs...))
+    end
+end
+@generated function Base.sprint{format}(::Type{FormatString{format}}, args...)
+    meta = Expr(:meta, :inline)
+    fmt = string(format)
+    allargs = [:(args[$d]) for d = 1:length(args)]
+    quote
+        @sprintf($fmt, $(allargs...))
+    end
+end
+
+#
+# USAGE: printf("%6d  %7.2f", 220/7, 22/7)
+#
+function printf(s::AbstractString, args...)
+    print(FormatString(s), args...)
+end
+function sprintf(s::AbstractString, args...)
+    print(FormatString(s), args...)
+end
+###########
+
 formatters = Dict{ ASCIIString, Function }()
 
 function sprintf1( fmt::ASCIIString, x )


### PR DESCRIPTION
This is an implementation of **printf()** and **sprintf()** that relies on generated functions, and the existing @printf and @sprintf macros. The key code was posted on the Julia mailing list by Tim Holy. I just added the small wrappers to make **printf()** and **sprintf()**.
