### PR TITLE
When inserting Enums, only print the enum value, not the ::Type part

### DIFF
--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -167,7 +167,10 @@ type _Bin end
 _srepr(x) = repr(x)
 _srepr(x::AbstractString) = x
 _srepr(x::Char) = string(x)
-_srepr(x::Enum) = string(x)
+
+if isdefined(:Enum)
+    _srepr(x::Enum) = string(x)
+end
 
 function printfmt(io::IO, fs::FormatSpec, x)
     cls = fs.cls

--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -39,7 +39,7 @@ immutable FormatSpec
     tsep::Bool   # whether to use thousand-separator
 
     function FormatSpec(typ::Char;
-               fill::Char=' ', 
+               fill::Char=' ',
                align::Char='\0',
                sign::Char='-',
                width::Int=-1,
@@ -167,6 +167,7 @@ type _Bin end
 _srepr(x) = repr(x)
 _srepr(x::AbstractString) = x
 _srepr(x::Char) = string(x)
+_srepr(x::Enum) = string(x)
 
 function printfmt(io::IO, fs::FormatSpec, x)
     cls = fs.cls


### PR DESCRIPTION
Currently, if you have:
``` julia
using Formatting
@enum MyEnum ValueA ValueB ValueC
a = ValueA
printfmtln("{}", a)
```
you get
```
julia> printfmtln("{}", a)
ValueA::MyEnum
```

I feel like when you're formatting a string to show an enum, you don't really care for type information, since a formatted string is generally produced to be human-friendly. This change modifies it to drop the `::MyEnum` part:

```
julia> printfmtln("{}", a)
ValueA
```

This change would bring `printfmt` in line with Julia's string interpolation, which is another reason why I believe this to be the more natural behavior:
```
julia> "$a"
"ValueA"
```

Of course, this is a suggestion, not a bug report—it seems intuitive to me, but whether this should in fact be the case is probably debatable. I'd appreciate hearing your thoughts on it.