### PR TITLE
Add printf1 function

### DIFF
--- a/src/Formatting.jl
+++ b/src/Formatting.jl
@@ -6,7 +6,7 @@ module Formatting
     export
         FormatSpec, FormatExpr,
         printfmt, printfmtln, fmt, format,
-        sprintf1, generate_formatter
+        sprintf1, printf1, generate_formatter
 
     include("cformat.jl" )
     include("fmtspec.jl")

--- a/src/cformat.jl
+++ b/src/cformat.jl
@@ -1,6 +1,8 @@
 formatters = Dict{ String, Function }()
 
 sprintf1( fmt::String, x ) = eval(Expr(:call, generate_formatter( fmt ), x))
+printf1( io::IO, fmt::String, x ) = print(io,sprintf1( fmt, x ))
+printf1( fmt::String, x ) = printf1( stdout, fmt, x )
 
 function checkfmt(fmt)
     @static if VERSION > v"1.6.0-DEV.854"


### PR DESCRIPTION
Implements `printf1([io],fmt,x)` function to work as a drop-in replacement for `@print`. 

A bit of a hack: simply calls `print(io,sprintf1(fmt, x))`, so offers no performance benefit over `sprintf1`, but is QOL. My original idea was to rewrite `sprintf1` into `printf1`, and make `sprintf1` work via an `IOBuffer`, but because `sprintf1` does several replacements and similar operations that require strings I decided to not touch it for now.

Temporary fix for https://github.com/JuliaIO/Formatting.jl/issues/91