### PR TITLE
Non-default thousands separator

### DIFF
--- a/src/Formatting.jl
+++ b/src/Formatting.jl
@@ -8,6 +8,8 @@ module Formatting
         printfmt, printfmtln, fmt, format,
         sprintf1, generate_formatter
 
+    const THOUSANDS_SEPARATOR = Ref(',')
+
     include("cformat.jl" )
     include("fmtspec.jl")
     include("fmtcore.jl")

--- a/src/cformat.jl
+++ b/src/cformat.jl
@@ -83,7 +83,7 @@ function addcommas( s::String )
             t = subs
         else
             if match( r"[0-9]", subs ) != nothing
-                t = subs * "," * t
+                t = subs * THOUSANDS_SEPARATOR[] * t
             else
                 t = subs * t
             end
@@ -345,7 +345,7 @@ function format( x::T;
                 s = reverse( replace( reverse(s), " " => "", count=length(s)-width ) )
             end
             if length(s) > width
-                s = replace( s, "," => "", count=length(s)-width )
+                s = replace( s, THOUSANDS_SEPARATOR[] => "", count=length(s)-width )
             end
         elseif length(s) < width
             if leftjustified

--- a/test/cformat.jl
+++ b/test/cformat.jl
@@ -146,7 +146,7 @@ function test_format()
     @test format( -302//30, mixedfraction=true,tryden = 100 ) == "-10_1/15" # lose precision otherwise
     @test format( -302//100, mixedfraction=true,tryden = 100,fractionwidth=6 ) == "-3_02/100" # lose precision otherwise
 
-    #commas
+    # commas
     @test format( 12345678, width=10, commas=true ) == "12,345,678"
     # it would try to squeeze out the commas
     @test format( 12345678, width=9, commas=true ) == "12345,678"
@@ -183,6 +183,13 @@ function test_format()
     @test format( 100.00, precision=2, suffix="%" ) == "100.00%"
     @test format( 100, precision=2, suffix="%" ) == "100%"
     @test format( 100, precision=2, suffix="%", conversion="f" ) == "100.00%"
+
+    old_sep = Char(Formatting.THOUSANDS_SEPARATOR[])  # change the default separator ...
+    Formatting.THOUSANDS_SEPARATOR[] = '_'
+    @test format( 12345678, width=10, commas=true ) == "12_345_678"
+    @test format( 12345678, width=9, commas=true ) == "12345_678"
+    Formatting.THOUSANDS_SEPARATOR[] = old_sep  # ... and restore it
+
 end
 
 test_commas()


### PR DESCRIPTION
Add the ability to change the default thousands separator.

```julia
julia> using Formatting
julia> Formatting.THOUSANDS_SEPARATOR[] = ' ';
julia> format(1_000_000, commas=true)
"1 000 000"
```

No performance penalty observed.

Fix https://github.com/JuliaIO/Formatting.jl/issues/45.